### PR TITLE
feat: add `global` insert variant

### DIFF
--- a/cli/insert_test.go
+++ b/cli/insert_test.go
@@ -69,6 +69,19 @@ func TestIdempotentNgsscProcessWithSetEnvironmentVariable(t *testing.T) {
 	assertContains(t, context.ReadFile("index.html"), expect, "Expected html to contain updated iife.")
 }
 
+func TestNgsscGlobalWithSetEnvironmentVariable(t *testing.T) {
+	context := newTestDir(t)
+	context.CreateFile("index.html", configHTMLTemplate)
+	context.CreateFile("ngssc.json", `{"variant":"global","environmentVariables":["TEST_VALUE"]}`)
+
+	os.Setenv("TEST_VALUE", "example value")
+	result := runWithArgs("insert", context.path)
+	os.Unsetenv("TEST_VALUE")
+	assertSuccess(t, result)
+	expect := `<script>(function(self){Object.assign(self,{"TEST_VALUE":"example value"});})(window)</script>`
+	assertContains(t, context.ReadFile("index.html"), expect, "Expected html to contain iife.")
+}
+
 func TestNgsscNgEnvWithNotSetEnvironmentVariable(t *testing.T) {
 	context := newTestDir(t)
 	context.CreateFile("index.html", configHTMLTemplate)

--- a/cli/ngssc_config.go
+++ b/cli/ngssc_config.go
@@ -69,7 +69,7 @@ func readNgsscJson(path string) (ngsscConfig NgsscConfig, err error) {
 		return ngsscConfig, fmt.Errorf("invalid ngssc.json at %v (Must not be empty)", path)
 	} else if ngssc.EnvironmentVariables == nil {
 		return ngsscConfig, fmt.Errorf("invalid ngssc.json at %v (environmentVariables must be defined)", path)
-	} else if ngssc.Variant != "process" && ngssc.Variant != "NG_ENV" {
+	} else if ngssc.Variant != "process" && ngssc.Variant != "global" && ngssc.Variant != "NG_ENV" {
 		return ngsscConfig, fmt.Errorf("invalid ngssc.json at %v (variant must either be process or NG_ENV)", path)
 	}
 
@@ -106,7 +106,9 @@ func (ngsscConfig NgsscConfig) BuildIifeScriptContent() string {
 	var iife string
 	if ngsscConfig.Variant == "NG_ENV" {
 		iife = fmt.Sprintf("self.NG_ENV=%v", envMapJSON)
-	} else {
+	} else if ngsscConfig.Variant == "global" {
+		iife = fmt.Sprintf("Object.assign(self,%v)", envMapJSON)
+		} else {
 		iife = fmt.Sprintf(`self.process={"env":%v}`, envMapJSON)
 	}
 

--- a/projects/angular-server-side-configuration/builders/dev-server/index.ts
+++ b/projects/angular-server-side-configuration/builders/dev-server/index.ts
@@ -56,7 +56,7 @@ function populateVariables(variables: string[]) {
 }
 
 function generateIife(
-  variant: 'process' | 'NG_ENV',
+  variant: 'process' | 'global' | 'NG_ENV',
   populatedVariables: { [key: string]: string | null }
 ) {
   const iife =

--- a/projects/angular-server-side-configuration/src/insert.spec.ts
+++ b/projects/angular-server-side-configuration/src/insert.spec.ts
@@ -14,11 +14,13 @@ describe('insert', () => {
     variant: 'process',
   };
   const envTestContent = 'TESTCONTENT';
-  const iife =
-    // tslint:disable-next-line: max-line-length
-    `<script>(function(self){self.process=${JSON.stringify({
-      env: { TEST: envTestContent, TEST2: null },
-    })};})(window)</script>`;
+  const iife = `<script>(function(self){self.process=${JSON.stringify({
+    env: { TEST: envTestContent, TEST2: null },
+  })};})(window)</script>`;
+  const globalIife = `<script>(function(self){Object.assign(self,${JSON.stringify({
+    TEST: envTestContent,
+    TEST2: null,
+  })});})(window)</script>`;
   const ngEnvIife = `<script>(function(self){self.NG_ENV=${JSON.stringify({
     TEST: envTestContent,
     TEST2: null,
@@ -105,6 +107,14 @@ describe('insert', () => {
   it('should do nothing on no html files', () => {
     writeFileSync(join(directory, 'ngssc.json'), JSON.stringify(ngssc), 'utf8');
     insert({ directory });
+  });
+
+  it('should insert into html with recursive true and variant global', () => {
+    createFiles('global');
+    insert({ directory, recursive: true });
+    for (const file of subdirectories.map((d) => join(d, 'index.html'))) {
+      expect(readFileSync(file, 'utf8')).toContain(globalIife);
+    }
   });
 
   it('should insert into html with recursive true and variant NG_ENV', () => {

--- a/projects/angular-server-side-configuration/src/insert.ts
+++ b/projects/angular-server-side-configuration/src/insert.ts
@@ -52,10 +52,14 @@ function populateVariables(variables: string[]) {
 }
 
 function generateIife(variant: Variant, populatedVariables: { [key: string]: string | null }) {
-  const iife =
-    variant === 'NG_ENV'
-      ? `(function(self){self.NG_ENV=${JSON.stringify(populatedVariables)};})(window)`
-      : `(function(self){self.process=${JSON.stringify({ env: populatedVariables })};})(window)`;
+  let iife:string;
+  if (variant === 'NG_ENV') {
+    iife = `(function(self){self.NG_ENV=${JSON.stringify(populatedVariables)};})(window)`;
+  } else if (variant === 'global') {
+    iife = `(function(self){Object.assign(self,${JSON.stringify(populatedVariables)});})(window)`;
+  } else {
+    iife = `(function(self){self.process=${JSON.stringify({ env: populatedVariables })};})(window)`;
+  }
   return `<!--ngssc--><script>${iife}</script><!--/ngssc-->`;
 }
 

--- a/projects/angular-server-side-configuration/src/ngssc.ts
+++ b/projects/angular-server-side-configuration/src/ngssc.ts
@@ -15,4 +15,4 @@ export interface Ngssc {
  * Available angular-server-side-configuration variants.
  * @public
  */
-export type Variant = 'process' | 'NG_ENV';
+export type Variant = 'process' | 'global' | 'NG_ENV';


### PR DESCRIPTION
The global insert variant inserts the environment variables
directly into the window object.
e.g. EXAMPLE => window.EXAMPLE

For now this is a insert variant only and cannot be configured via
builder.