### PR TITLE
feat: rename `browserTarget` to `buildTarget` and add migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ by replacing `production` with your configuration name in the previous command.
 
 The builder will analyze `.ts` files in the project to detect
 used environment variables and generate an [ngssc.json](#ngsscjson) in the defined
-`outputPath` in the referenced `browserTarget`.
+`outputPath` in the referenced `buildTarget` (previously `browserTargeet`).
 
 ```json
 ...
@@ -98,7 +98,7 @@ used environment variables and generate an [ngssc.json](#ngsscjson) in the defin
           "builder": "angular-server-side-configuration:ngsscbuild",
           "options": {
             "additionalEnvironmentVariables": ["MANUAL_ENTRIES"],
-            "browserTarget": "your-project-name:build",
+            "buildTarget": "your-project-name:build",
             // Optional
             // (Defaults to the basename of the index option of the browser target)
             "filePattern": "index.html",
@@ -107,7 +107,7 @@ used environment variables and generate an [ngssc.json](#ngsscjson) in the defin
           },
           "configurations": {
             "production": {
-              "browserTarget": "your-project-name:build:production"
+              "buildTarget": "your-project-name:build:production"
             }
           }
         }

--- a/angular.json
+++ b/angular.json
@@ -109,11 +109,11 @@
           "builder": "./dist/angular-server-side-configuration:ngsscbuild",
           "options": {
             "additionalEnvironmentVariables": ["MANUAL_VALUE"],
-            "browserTarget": "ngssc-app:build"
+            "buildTarget": "ngssc-app:build"
           },
           "configurations": {
             "production": {
-              "browserTarget": "ngssc-app:build:production"
+              "buildTarget": "ngssc-app:build:production"
             }
           }
         }
@@ -202,10 +202,10 @@
           "builder": "./dist/angular-server-side-configuration:dev-server",
           "configurations": {
             "production": {
-              "browserTarget": "ngssc-builders-app:build:production"
+              "buildTarget": "ngssc-builders-app:build:production"
             },
             "development": {
-              "browserTarget": "ngssc-builders-app:build:development"
+              "buildTarget": "ngssc-builders-app:build:development"
             }
           },
           "defaultConfiguration": "development"

--- a/projects/angular-server-side-configuration/builders/ngsscbuild/index.ts
+++ b/projects/angular-server-side-configuration/builders/ngsscbuild/index.ts
@@ -15,19 +15,19 @@ const readFileAsync = promises.readFile;
 const writeFileAsync = promises.writeFile;
 
 export async function ngsscBuild(options: NgsscBuildSchema, context: BuilderContext) {
-  const browserTarget = targetFromTargetString(options.browserTarget);
-  const rawBrowserOptions = await context.getTargetOptions(browserTarget);
-  const browserName = await context.getBuilderNameForTarget(browserTarget);
+  const buildTarget = targetFromTargetString(options.buildTarget || options.browserTarget);
+  const rawBrowserOptions = await context.getTargetOptions(buildTarget);
+  const browserName = await context.getBuilderNameForTarget(buildTarget);
   const browserOptions = await context.validateOptions<json.JsonObject & BrowserBuilderOptions>(
     rawBrowserOptions,
     browserName,
   );
-  const scheduledTarget = await context.scheduleTarget(browserTarget);
+  const scheduledTarget = await context.scheduleTarget(buildTarget);
   const result = await scheduledTarget.result;
   if (!result.success) {
-    const buildConfig = browserTarget.configuration ? `:${browserTarget.configuration}` : '';
+    const buildConfig = buildTarget.configuration ? `:${buildTarget.configuration}` : '';
     context.logger.warn(
-      `ngssc: Failed build of ${browserTarget.app}:${browserTarget.target}${buildConfig}. Skipping ngssc build.`,
+      `ngssc: Failed build of ${buildTarget.app}:${buildTarget.target}${buildConfig}. Skipping ngssc build.`,
     );
     return result;
   }

--- a/projects/angular-server-side-configuration/builders/ngsscbuild/schema.json
+++ b/projects/angular-server-side-configuration/builders/ngsscbuild/schema.json
@@ -8,7 +8,14 @@
     },
     "browserTarget": {
       "type": "string",
-      "description": "The build target to execute"
+      "description": "A browser builder target to build in the format of `project:target[:configuration]`.",
+      "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$",
+      "x-deprecated": "Use 'buildTarget' instead."
+    },
+    "buildTarget": {
+      "type": "string",
+      "description": "A build builder target to build in the format of `project:target[:configuration]`.",
+      "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$"
     },
     "filePattern": {
       "type": "string",
@@ -20,5 +27,6 @@
       "description": "The search pattern to use when searching for environment variable occurrences (Defaults to {sourceRoot}/**/environments/environment*.ts)",
       "default": ""
     }
-  }
+  },
+  "anyOf": [{ "required": ["buildTarget"] }, { "required": ["browserTarget"] }]
 }

--- a/projects/angular-server-side-configuration/builders/ngsscbuild/schema.ts
+++ b/projects/angular-server-side-configuration/builders/ngsscbuild/schema.ts
@@ -1,6 +1,8 @@
 export interface Schema {
   additionalEnvironmentVariables: string[];
+  /** @deprecated Use buildTarget instead. */
   browserTarget: string;
+  buildTarget: string;
   filePattern: string | null;
   searchPattern?: string | null;
 }

--- a/projects/angular-server-side-configuration/schematics/migration.json
+++ b/projects/angular-server-side-configuration/schematics/migration.json
@@ -6,6 +6,11 @@
       "description": "Updates angular-server-side-configuration to v15",
       "factory": "./ng-update/index#updateToV15"
     },
+    "migration-v17": {
+      "version": "17-next",
+      "description": "Updates angular-server-side-configuration to v17",
+      "factory": "./ng-update/index#updateToV17"
+    },
     "dockerfile": {
       "version": "16.0.0",
       "description": "Updates the download url for ngssc",

--- a/projects/angular-server-side-configuration/schematics/ng-add/index.ts
+++ b/projects/angular-server-side-configuration/schematics/ng-add/index.ts
@@ -62,11 +62,11 @@ function addNgsscTargetToWorkspace(options: Schema): Rule {
         builder: 'angular-server-side-configuration:ngsscbuild',
         options: {
           ...ngsscOptions,
-          browserTarget: `${options.project}:build`,
+          buildTarget: `${options.project}:build`,
         },
         configurations: {
           production: {
-            browserTarget: `${options.project}:build:production`,
+            buildTarget: `${options.project}:build:production`,
           },
         },
       });

--- a/projects/angular-server-side-configuration/schematics/ng-update/index.spec.ts
+++ b/projects/angular-server-side-configuration/schematics/ng-update/index.spec.ts
@@ -40,7 +40,7 @@ describe('ng-update', () => {
     );
   });
 
-  it('should remove ngsscEnvironmentFile on v9 update', async () => {
+  it('should remove ngsscEnvironmentFile on v15 update', async () => {
     runner.registerCollection('schematics', join(__dirname, '../collection.json'));
     const tree = await runner.runExternalSchematic(
       'schematics',
@@ -58,6 +58,29 @@ describe('ng-update', () => {
     expect(
       'ngsscEnvironmentFile' in angularJson.projects[appOptions.name].architect.ngsscbuild.options,
     ).toBeFalse();
+  });
+
+  it('should remove ngsscEnvironmentFile on v15 update', async () => {
+    runner.registerCollection('schematics', join(__dirname, '../collection.json'));
+    const tree = await runner.runExternalSchematic(
+      'schematics',
+      'ng-add',
+      { project: appOptions.name },
+      appTree,
+    );
+    await updateWorkspace((workspace) => {
+      const options = workspace.projects.get(appOptions.name)!.targets.get('ngsscbuild')!.options!;
+      options['browserTarget'] = options['buildTarget'];
+      delete options['buildTarget'];
+    })(tree, undefined as any);
+    const migratedTree = await runner.runSchematic('migration-v17', {}, tree);
+    const angularJson = JSON.parse(migratedTree.readContent('angular.json'));
+    expect(
+      'browserTarget' in angularJson.projects[appOptions.name].architect.ngsscbuild.options,
+    ).toBeFalse();
+    expect(
+      angularJson.projects[appOptions.name].architect.ngsscbuild.options['buildTarget'],
+    ).toEqual('dummy:build');
   });
 
   it('should update Dockerfile', async () => {

--- a/projects/angular-server-side-configuration/schematics/ng-update/index.ts
+++ b/projects/angular-server-side-configuration/schematics/ng-update/index.ts
@@ -27,6 +27,32 @@ export function updateToV15(): Rule {
   };
 }
 
+export function updateToV17(): Rule {
+  return (_tree: Tree, context: SchematicContext) => {
+    return updateWorkspace((workspace) => {
+      context.logger.info(`Renaming 'browserTarget' to 'buildTarget'.`);
+      workspace.projects.forEach((project, name) => {
+        const ngsscbuild = project.targets.get('ngsscbuild');
+        if (!ngsscbuild || !ngsscbuild.options) {
+          return;
+        }
+
+        if ('browserTarget' in ngsscbuild.options) {
+          ngsscbuild.options['buildTarget'] = ngsscbuild.options['browserTarget'];
+          delete ngsscbuild.options['browserTarget'];
+        }
+        Object.keys(ngsscbuild.configurations || {})
+          .filter((c) => 'browserTarget' in ngsscbuild.configurations![c]!)
+          .forEach((c) => {
+            ngsscbuild.configurations![c]!['buildTarget'] =
+              ngsscbuild.configurations![c]!['browserTarget'];
+            delete ngsscbuild.configurations![c]!['browserTarget'];
+          });
+      });
+    });
+  };
+}
+
 export function dockerfile(): Rule {
   return (tree: Tree) => {
     const downloadUrlRegex =

--- a/scripts/build-lib.mts
+++ b/scripts/build-lib.mts
@@ -32,6 +32,7 @@ async function finalizePackage() {
   const ngsscSchema: Schema = JSON.parse(
     await readFile(join(sourceDir, 'builders/ngsscbuild/schema.json'), 'utf8')
   );
+  delete ngsscSchema.properties['buildTarget'];
   delete ngsscSchema.properties['browserTarget'];
   for (const schemaVariant of ['browser', 'dev-server']) {
     const sourceFile = join(


### PR DESCRIPTION
This is in alignment with the Angular CLI.