### PR TITLE
feat: bump Go version to fix CVEs

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.17-alpine
+FROM golang:1.22-alpine
 RUN apk add upx
 RUN apk add git


### PR DESCRIPTION
The following critical CVEs are fixed by bumping the Go version: CVE-2022-23806, CVE-2023-24538 and CVE-2023-24540