### PR TITLE
refactor: remove unused binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - run: go version
 
       - name: 'Build cli'
-        run: yarn build:cli:upx
+        run: yarn build:cli
 
       - uses: actions/github-script@v6
         with:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build:lib": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only ./scripts/build-lib.mts",
     "build:cli": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only ./scripts/build-cli.mts",
-    "build:cli:upx": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only ./scripts/build-cli.mts upx",
     "build:ngssc": "ng run ngssc-app:ngsscbuild:production",
     "build:demo": "ng build ngssc-app",
     "build:demo-i18n": "ng build ngssc-app -c i18n",

--- a/scripts/build-cli.mts
+++ b/scripts/build-cli.mts
@@ -9,15 +9,12 @@ const dist = join(root, 'dist', 'cli');
 const version = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version;
 const cliDirectory = join(root, 'cli');
 const binaries: { os: string; arch: string; fileName: string, alias?: string }[] = [
-  { os: 'windows', arch: '386', fileName: 'ngssc_32bit.exe' },
   { os: 'windows', arch: 'amd64', fileName: 'ngssc_amd64.exe', alias: 'ngssc_64bit.exe' },
-  { os: 'linux', arch: '386', fileName: 'ngssc_32bit' },
   { os: 'linux', arch: 'amd64', fileName: 'ngssc_amd64', alias: 'ngssc_64bit' },
   { os: 'linux', arch: 'arm64', fileName: 'ngssc_arm64' },
   { os: 'darwin', arch: 'amd64', fileName: 'ngssc_darwin_amd64', alias: 'ngssc_darwin_64bit' },
   { os: 'darwin', arch: 'arm64', fileName: 'ngssc_darwin_arm64' },
 ];
-const buildUpx = process.argv[2] === 'upx';
 
 const asyncExec = promisify(exec);
 await Promise.all(
@@ -39,22 +36,6 @@ await Promise.all(
     if (binary.alias) {
       await cp(binaryDist, join(dist, binary.alias));
       console.log(`Created alias for ${binary.os} ${binary.arch}: ${binary.alias}`);
-    }
-
-    if (buildUpx) {
-      const [fileName, extension] = binary.fileName.split('.');
-      const minFileName = `${fileName}_min${extension ? `.${extension}` : ''}`;
-      const minBinaryDist = join(dist, minFileName);
-      console.log(`Building upx binary for ${binary.os} ${binary.arch}`);
-      await cp(binaryDist, minBinaryDist);
-      await asyncExec(`upx --brute ${minBinaryDist}`);
-      console.log(`Finished compressing binary for ${binary.os} ${binary.arch}: ${minFileName}`);
-      if (binary.alias) {
-        const [fileName, extension] = binary.alias.split('.');
-        const aliasFileName = `${fileName}_min${extension ? `.${extension}` : ''}`;
-        await cp(minBinaryDist, join(dist, aliasFileName));
-        console.log(`Created alias for compressed ${binary.os} ${binary.arch}: ${aliasFileName}`);
-      }
     }
   }),
 );


### PR DESCRIPTION
The minified and 32bit binaries have not been in use for a while. As such this PR removes them.